### PR TITLE
Synopsys: Automated PR: Update Blackduck Vulnerable Components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,10 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.hibernate:hibernate-core:5.3.0.Final'
-    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.hibernate:hibernate-core:5.6.15.Final'
+    implementation 'log4j:log4j:1.3alpha8-temp'
     implementation 'commons-logging:commons-logging:1.1.1'
-    implementation 'commons-fileupload:commons-fileupload:1.3.3'
+    implementation 'commons-fileupload:commons-fileupload:1.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -47,7 +47,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.43.0.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
[Click Here To See All Vulnerable Components](https://testing.blackduck.synopsys.com/api/projects/ba45a7d9-1599-46e0-bf85-2ccd39e0737f/versions/352076c1-ecc8-458f-b926-633a5b2cae94/vulnerability-bom)
## Vulnerabilities associated with this PR
### log4j:log4j:1.2.17
#### BDSA-2022-0119
Apache Log4j **1.2.x** versions are vulnerable to SQL injection (SQLi). This may allow an attacker to insert SQL queries into messages being logged that will get executed against a backend database. 

**Note:** This issue  affects versions **1.2.x** that are configured to use the `JDBCAppender`...
#### BDSA-2022-0118
Apache Log4j is vulnerable to a remote code execution (RCE) issue due to how the Apache Chainsaw component can unsafely deserialize user controlled input.

An attacker could send crafted input to the application in order to abuse the flaw and execute malicious code on the system...
#### BDSA-2022-0117
Log4j is vulnerable to remote code execution (RCE) due to the deserialization of untrusted data...
#### BDSA-2021-4371
Apache chainsaw is vulnerable to a deserialization of untrusted data flaw. A remote attacker could leverage this to cause remote code execution (RCE).
#### BDSA-2019-4008
Apache Log4j is vulnerable to remote code execution (RCE).  This allows a remote attacker to send a crafted serialized payload that, when processed by Log4j, will execute arbitrary code. This can occur if Log4j is deserializing untrusted network traffic.
#### BDSA-2021-3764
Log4j **1.x** versions are vulnerable to deserializing untrusted data if configured to use `JMSAppender` (which is not the default). A remote attacker could leverage this to execute arbitrary code on the underlying system with the privileges of the application that is running Log4j...
#### BDSA-2020-1398
Apache Log4j is vulnerable to man-in-the-middle (MITM) attacks due to improper SSL certificate validation due to host name mismatch. An attacker could exploit this by mounting a man-in-the-middle attack which could leak log messages sent through SMTPS.
### org.hibernate:hibernate-core:5.3.0.Final
#### BDSA-2020-3410
Hibernate ORM is vulnerable to SQL injection due to the unsafe implementation of comments that are intended for debugging purposes. A remote attacker could potentially recover...
#### BDSA-2019-4479
Hibernate ORM is vulnerable to SQL injection (SQLi) due to insufficient validation of user-controlled input. An attacker may be able to obtain unauthorized information from the database by executing arbitrary SQL commands.
### org.xerial:sqlite-jdbc:3.36.0.3
#### BDSA-2023-1552
SQLite JDBC contains a code injection vulnerability. A remote attacker could exploit this vulnerability by gaining control of a JDBC URL in order to achieve remote code execution (RCE).
### commons-fileupload:commons-fileupload:1.3.3
#### BDSA-2023-0357
Apache Commons FileUpload does not sufficiently limit the the number of request parts that can be received via user input. An attacker can exploit this flaw by supplying a malicious upload or series of uploads and cause excessive resource allocation. This can trigger a denial-of-service (DoS)...
